### PR TITLE
Don't ship JRE debugging symbols

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
+    "skip-icons-check": "true",
     "skip-arches": ["arm"]
 }

--- a/org.videolan.VLC.Plugin.bdj.json
+++ b/org.videolan.VLC.Plugin.bdj.json
@@ -21,7 +21,7 @@
         "buildsystem": "simple",
         "build-commands": [
           "mkdir -p /app/share/vlc/extra/bdj/jre",
-          "cp -ar /usr/lib/sdk/openjdk8/jvm/java-8-openjdk/{bin,lib} /app/share/vlc/extra/bdj/jre",
+          "cp -ar /usr/lib/sdk/openjdk8/jvm/java-8-openjdk/jre/{bin,lib} /app/share/vlc/extra/bdj/jre",
           "find /app/share/vlc/extra/bdj/jre -type f -name '*.diz' -delete"
         ]
     },

--- a/org.videolan.VLC.Plugin.bdj.json
+++ b/org.videolan.VLC.Plugin.bdj.json
@@ -21,8 +21,8 @@
         "buildsystem": "simple",
         "build-commands": [
           "mkdir -p /app/share/vlc/extra/bdj/jre",
-          "cp -r /usr/lib/sdk/openjdk8/jvm/java-8-openjdk/* /app/share/vlc/extra/bdj/jre",
-          "rm -rf /app/share/vlc/extra/bdj/jre/src.zip /app/share/vlc/extra/bdj/jre/include /app/share/vlc/extra/bdj/jre/demo /app/share/vlc/extra/bdj/jre/sample"
+          "cp -ar /usr/lib/sdk/openjdk8/jvm/java-8-openjdk/{bin,lib} /app/share/vlc/extra/bdj/jre",
+          "find /app/share/vlc/extra/bdj/jre -type f -name '*.diz' -delete"
         ]
     },
     {


### PR DESCRIPTION
These symbols were being shipped to users, which ended up making this extension unnecessarily bigger.