### PR TITLE
Fix Reference To 'libbluray.jar'

### DIFF
--- a/org.videolan.VLC.Plugin.bdj.json
+++ b/org.videolan.VLC.Plugin.bdj.json
@@ -7,7 +7,7 @@
   "sdk": "org.freedesktop.Sdk//20.08",
   "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk8"],
   "separate-locales": false,
- "appstream-compose": false,
+  "appstream-compose": false,
   "build-options": {
     "env": {
       "V": "1",
@@ -15,6 +15,9 @@
     },
     "append-path": "/usr/lib/sdk/openjdk8/bin"
   },
+  "cleanup-commands": [
+    "ln -s /app/share/vlc/extra/bdj/share/java/libbluray-j2se-1.2.1.jar /app/share/vlc/extra/bdj/share/java/libbluray.jar"
+  ],
   "modules": [
     {
       "name": "openjdk",
@@ -35,9 +38,9 @@
       "sources": [
         {
           "type": "file",
-          "url": "http://apache.mirrors.ovh.net/ftp.apache.org/dist//ant/binaries/apache-ant-1.10.9-bin.tar.bz2",
+          "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.tar.bz2",
           "dest-filename": "apache-ant-bin.tar.bz2",
-          "sha512": "e74f490c64addfb5040ee80d38d4de3057b8fc7c58dd627dd77883964fd41edfc208230f45ee5500d70fc07a2f81a1d8d069a3b70ed6055c2975c49d753b73bc"
+          "sha512": "3587dfdcbc35c49ee21949cab0306adb2a7e679d6cf90e3030cf5d264db2411a3957d896c467a39806ac53bc6080b94182f233aa3e5d7ba327d82a6ab24748a4"
         }
       ]
     },
@@ -50,8 +53,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "http://ftp.videolan.org/videolan/libbluray/1.2.1/libbluray-1.2.1.tar.bz2",
-          "sha256": "5223e83f7988ea2cc860b5cadcaf9cf971087b0c80ca7b60cc17c8300cae36ec"
+          "url": "http://ftp.videolan.org/videolan/libbluray/1.3.0/libbluray-1.3.0.tar.bz2",
+          "sha256": "e2dbaf99e84e0a9725f4985bcb85d41e52c2261cc651d8884b1b790b5ef016f9"
         }
       ]
     },


### PR DESCRIPTION
* Running the current 'org.videolan.VLC' flatpak with `flatpak run --verbose org.videolan.VLC -v` we can see the error while it tries to initialize blu-ray menu's is because 'libbluray.jar' does not exist. This patch links it to 'libbluray-j2se-1.2.1.jar'. I'm not sure if this is the most correct solution to the problem but it works.
* I updated 'libbluray' to match what is used in 'org.videolan.VLC' to prevent any issues with Java side running with a library that wasn't the same as what VLC would end up using.
* I updated 'ant' to the latest of the 1.10 series and switched the URL. This might not be the most preferable from the Apache side but the other URLs seem to have been unreliable (and initially prevented my rebuilding as well with 404s).
* Minor spacing touch-up for the appstream-compose line.

I'm only applying the patch here because I know the current version of the 'org.videolan.VLC' app looks to this plugin branch. Testing locally I was able to load a menu with my blu-ray that I was previously unable to do.

Fixes flathub/org.videolan.VLC#55, fixes flathub/org.videolan.VLC#127