### PR TITLE
Use Java 8 since it seems to be the most compatible

### DIFF
--- a/bdj-env.sh
+++ b/bdj-env.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
 export PATH=/app/share/vlc/extra/bdj/jre/bin:$PATH
 export JAVA_HOME=/app/share/vlc/extra/bdj/jre
 export LIBBLURAY_CP=/app/share/vlc/extra/bdj/share/java/
+

--- a/org.videolan.VLC.Plugin.bdj.json
+++ b/org.videolan.VLC.Plugin.bdj.json
@@ -5,15 +5,15 @@
   "runtime-version": "stable",
   "branch": "3-23.08",
   "sdk": "org.freedesktop.Sdk//23.08",
-  "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk11"],
+  "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk8"],
   "separate-locales": false,
  "appstream-compose": false,
   "build-options": {
     "env": {
       "V": "1",
-      "JAVA_HOME": "/usr/lib/sdk/openjdk11"
+      "JAVA_HOME": "/usr/lib/sdk/openjdk8"
     },
-    "append-path": "/usr/lib/sdk/openjdk11/bin"
+    "append-path": "/usr/lib/sdk/openjdk8/bin"
   },
   "modules": [
     {
@@ -21,7 +21,7 @@
         "buildsystem": "simple",
         "build-commands": [
           "mkdir -p /app/share/vlc/extra/bdj/jre",
-          "cp -r /usr/lib/sdk/openjdk11/jvm/openjdk-11/* /app/share/vlc/extra/bdj/jre",
+          "cp -r /usr/lib/sdk/openjdk8/jvm/java-8-openjdk/* /app/share/vlc/extra/bdj/jre",
           "rm -rf /app/share/vlc/extra/bdj/jre/lib/src.zip /app/share/vlc/extra/bdj/jre/lib/ct.sym",
           "rm -rf /app/share/vlc/extra/bdj/jre/include /app/share/vlc/extra/bdj/jre/demo /app/share/vlc/extra/bdj/jre/sample"
         ]
@@ -36,9 +36,9 @@
       "sources": [
         {
           "type": "file",
-          "url": "http://apache.mirrors.ovh.net/ftp.apache.org/dist/ant/binaries/apache-ant-1.10.12-bin.tar.bz2",
+          "url": "http://apache.mirrors.ovh.net/ftp.apache.org/dist/ant/binaries/apache-ant-1.10.14-bin.tar.bz2",
           "dest-filename": "apache-ant-bin.tar.bz2",
-          "sha256": "276ea73f267a5b1a58f02e2eb5ef594a9b2885e33afb05ef995251d4d18377a6"
+          "sha256": "4c19450831001e6e9d5d2a94c3350f542f04f44f070085759c24f39d3cda928d"
         }
       ]
     },


### PR DESCRIPTION
It seems that using an older JVM improves compatibility since the VM used in Blu-ray players is probably from even before that.