### PR TITLE
Use JDK 17 instead

### DIFF
--- a/org.videolan.VLC.Plugin.bdj.json
+++ b/org.videolan.VLC.Plugin.bdj.json
@@ -5,13 +5,13 @@
   "runtime-version": "stable",
   "branch": "3-25.08",
   "sdk": "org.freedesktop.Sdk//25.08",
-  "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk11"],
+  "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk17"],
   "build-options": {
     "env": {
       "V": "1",
-      "JAVA_HOME": "/usr/lib/sdk/openjdk11"
+      "JAVA_HOME": "/usr/lib/sdk/openjdk17"
     },
-    "append-path": "/usr/lib/sdk/openjdk11/bin"
+    "append-path": "/usr/lib/sdk/openjdk17/bin"
   },
   "modules": [
     {
@@ -19,9 +19,9 @@
         "buildsystem": "simple",
         "build-commands": [
           "mkdir -p /app/share/vlc/extra/bdj/jre/bin",
-          "cp -ra /usr/lib/sdk/openjdk11/jvm/openjdk-11/{conf,lib,release} /app/share/vlc/extra/bdj/jre/",
+          "cp -ra /usr/lib/sdk/openjdk17/jvm/openjdk-17/{conf,lib,release} /app/share/vlc/extra/bdj/jre/",
           "rm /app/share/vlc/extra/bdj/jre/lib/src.zip /app/share/vlc/extra/bdj/jre/lib/ct.sym",
-          "cp -ra /usr/lib/sdk/openjdk11/jvm/openjdk-11/bin/{java,keytool,rmiregistry} /app/share/vlc/extra/bdj/jre/bin"
+          "cp -ra /usr/lib/sdk/openjdk17/jvm/openjdk-17/bin/{java,keytool,rmiregistry} /app/share/vlc/extra/bdj/jre/bin"
         ]
     },
     {

--- a/org.videolan.VLC.Plugin.bdj.json
+++ b/org.videolan.VLC.Plugin.bdj.json
@@ -5,13 +5,13 @@
   "runtime-version": "stable",
   "branch": "3-25.08",
   "sdk": "org.freedesktop.Sdk//25.08",
-  "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk21"],
+  "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk11"],
   "build-options": {
     "env": {
       "V": "1",
-      "JAVA_HOME": "/usr/lib/sdk/openjdk21"
+      "JAVA_HOME": "/usr/lib/sdk/openjdk11"
     },
-    "append-path": "/usr/lib/sdk/openjdk21/bin"
+    "append-path": "/usr/lib/sdk/openjdk11/bin"
   },
   "modules": [
     {
@@ -19,9 +19,9 @@
         "buildsystem": "simple",
         "build-commands": [
           "mkdir -p /app/share/vlc/extra/bdj/jre/bin",
-          "cp -ra /usr/lib/sdk/openjdk21/jvm/openjdk-21/{conf,lib,release} /app/share/vlc/extra/bdj/jre/",
+          "cp -ra /usr/lib/sdk/openjdk11/jvm/openjdk-11/{conf,lib,release} /app/share/vlc/extra/bdj/jre/",
           "rm /app/share/vlc/extra/bdj/jre/lib/src.zip /app/share/vlc/extra/bdj/jre/lib/ct.sym",
-          "cp -ra /usr/lib/sdk/openjdk21/jvm/openjdk-21/bin/{java,keytool,rmiregistry} /app/share/vlc/extra/bdj/jre/bin"
+          "cp -ra /usr/lib/sdk/openjdk11/jvm/openjdk-11/bin/{java,keytool,rmiregistry} /app/share/vlc/extra/bdj/jre/bin"
         ]
     },
     {


### PR DESCRIPTION
I accidentally closed the previous one (sorry).
After the great MatMaul fixed the libbluray issue, i wanted to watch my Better Call Saul, only to find VLC hanging indefinently. The logs are attached below for interested parties.
I propose that we just use Java 11 since that basically was a drop-in solution.
```
flatpak run org.videolan.VLC
VLC media player 3.0.23 Vetinari (revision 3.0.23-2-0-g79128878dd)
[000055c71eeb4710] main libvlc: Running vlc with the default interface. Use 'cvlc' to use vlc without interface.
Qt: Session management error: Could not open network socket
[000055c71ef6b040] main playlist: playlist is empty
uint DBusMenuExporterDBus::GetLayout(int, int, const QStringList&, DBusMenuLayoutItem&): Condition failed: menu
[00007f1ba80011a0] libbluray demux: First play: 1, Top menu: 1
HDMV Titles: 17, BD-J Titles: 3, Other: 0
[0,073s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Logger.logN(ZLjava/lang/String;ILjava/lang/String;)V from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.getAacsDataN(JI)[B from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.getUOMaskN(J)J from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.setUOMaskN(JZZ)V from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.setKeyInterestN(JI)V from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.getTitleInfosN(J)[Lorg/videolan/TitleInfo; from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.getPlaylistInfoN(JI)Lorg/videolan/PlaylistInfo; from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.seekN(JIIJ)J from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.selectPlaylistN(JIIIJ)I from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.selectTitleN(JI)I from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.setVirtualPackageN(JLjava/lang/String;Z)I from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.selectAngleN(JI)I from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.soundEffectN(JI)I from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.tellTimeN(J)J from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.selectRateN(JFI)I from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.writeRegN(JIIII)I from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.readRegN(JII)I from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.cacheBdRomFileN(JLjava/lang/String;Ljava/lang/String;)I from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.listBdFilesN(JLjava/lang/String;Z)[Ljava/lang/String; from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.getBdjoN(JLjava/lang/String;)Lorg/videolan/bdjo/Bdjo; from code in a different classloader
[0,074s][warning][jni,resolve] Re-registering of platform native method: org.videolan.Libbluray.updateGraphicN(JII[IIIII)V from code in a different classloader
[0,092s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDFontMetrics.initN()J from code in a different classloader
[0,092s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDFontMetrics.destroyN(J)V from code in a different classloader
[0,092s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDFontMetrics.resolveFontN(Ljava/lang/String;I)Ljava/lang/String; from code in a different classloader
[0,092s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDFontMetrics.unloadFontConfigN()V from code in a different classloader
[0,092s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDFontMetrics.getFontFamilyAndStyleN(JLjava/lang/String;)[Ljava/lang/String; from code in a different classloader
[0,092s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDFontMetrics.loadFontN(JLjava/lang/String;I)J from code in a different classloader
[0,092s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDFontMetrics.destroyFontN(J)V from code in a different classloader
[0,092s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDFontMetrics.charWidthN(JC)I from code in a different classloader
[0,092s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDFontMetrics.stringWidthN(JLjava/lang/String;)I from code in a different classloader
[0,092s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDFontMetrics.charsWidthN(J[CII)I from code in a different classloader
[0,093s][warning][jni,resolve] Re-registering of platform native method: java.awt.BDGraphicsBase.drawStringN(JLjava/lang/String;III)V from code in a different classloader
Libbluray.java:org.videolan.Libbluray.setSecurityManager:148: Detected Java >= 18, trying setSecurityManager() workaround
VFSCache.java:org.videolan.VFSCache.init:61: disc root is in UDF
uint DBusMenuExporterDBus::GetLayout(int, int, const QStringList&, DBusMenuLayoutItem&): Condition failed: menu
PrintStream.java:java.io.PrintStream.println:1194: java.io.FileNotFoundException: /tmp/libbluray-bdj-cache/df7dd0b3f4/VFSCache/BDMV/JAR/03001/projectsettings.xml (No such file or directory)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/java.io.FileInputStream.open0(Native Method)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/java.io.FileInputStream.openImpl(FileInputStream.java:116)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/java.io.FileInputStream.<init>(FileInputStream.java:79)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/java.io.FileInputStream.<init>(FileInputStream.java:96)

PrintStream.java:java.io.PrintStream.println:1194:      at com.spe.radius.StandardMenuXlet.eE(Unknown Source)

PrintStream.java:java.io.PrintStream.println:1194:      at com.spe.radius.StandardMenuXlet.initXlet(Unknown Source)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/org.videolan.BDJAppProxy.doInit(BDJAppProxy.java:252)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/org.videolan.BDJAppProxy.run(BDJAppProxy.java:360)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/java.lang.Thread.run(Thread.java:1583)

PrintStream.java:java.io.PrintStream.println:1194: java.io.FileNotFoundException: /tmp/libbluray-bdj-cache/df7dd0b3f4/VFSCache/BDMV/JAR/03001/bluray_project.bin (No such file or directory)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/java.io.FileInputStream.open0(Native Method)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/java.io.FileInputStream.openImpl(FileInputStream.java:116)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/java.io.FileInputStream.<init>(FileInputStream.java:79)

PrintStream.java:java.io.PrintStream.println:1194:      at vq.getBytesFromFile(Unknown Source)

PrintStream.java:java.io.PrintStream.println:1194:      at vq.loadProject(Unknown Source)

PrintStream.java:java.io.PrintStream.println:1194:      at com.spe.radius.StandardMenuXlet.startXlet(Unknown Source)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/org.videolan.BDJAppProxy.doStart(BDJAppProxy.java:270)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/org.videolan.BDJAppProxy.run(BDJAppProxy.java:365)

PrintStream.java:java.io.PrintStream.println:1194:      at java.base/java.lang.Thread.run(Thread.java:1583)

org.videolan.BDJAppProxy:0: ERROR: doStart() failed: java.lang.NullPointerException: Cannot invoke "String.length()" because "<parameter1>" is null
        bt.at(Unknown Source)
        bv.dZ(Unknown Source)
        com.spe.radius.StandardMenuXlet.startXlet(Unknown Source)
        java.base/org.videolan.BDJAppProxy.doStart(BDJAppProxy.java:270)
        java.base/org.videolan.BDJAppProxy.run(BDJAppProxy.java:365)
        java.base/java.lang.Thread.run(Thread.java:1583)
org.videolan.BDJSocketFactory:0: ERROR: Failed to create socket: java.lang.NoSuchMethodException: java.net.SocksSocketImpl.<init>() at  java.base/org.videolan.BDJSocketFactory.createSocketImpl(BDJSocketFactory.java:74)
        java.base/java.net.Socket.createImpl(Socket.java:573)
        java.base/java.net.Socket.<init>(Socket.java:182)
        java.base/javax.net.ssl.SSLSocket.<init>(SSLSocket.java:205)
        java.base/sun.security.ssl.BaseSSLSocketImpl.<init>(BaseSSLSocketImpl.java:68)
        java.base/sun.security.ssl.SSLSocketImpl.<init>(SSLSocketImpl.java:122)
        java.base/sun.security.ssl.SSLSocketFactoryImpl.createSocket(SSLSocketFactoryImpl.java:72)
        java.base/sun.net.www.protocol.https.HttpsClient.createSocket(HttpsClient.java:419)
        java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:163)
        java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:531)
        java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:636)
        java.base/sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:264)
        java.base/sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:377)
        java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:193)
        java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1257)
        java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1143)
        java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:179)
        java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.connect(HttpsURLConnectionImpl.java:141)
        su.a(Unknown Source)
        su.fx(Unknown Source)
        sw.run(Unknown Source)
        java.base/java.lang.Thread.run(Thread.java:1583)
```